### PR TITLE
changes for v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.2.2
+## Fixed
+- Fixed an issue where the tool would panic if the max iterations on consensus was reached instead of returning the last result
+- Fixed an issue where the consensus could "ping-pong" between two answers and not converge
+- Fixed an issue caused by reads that are unexpectedly large (>75 kbp) by filtering them
+
 # v0.2.1
 ## Fixed
 - Fixed a panic caused by putative deletion at the first reference chrM base

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ***
 
-Mitorsaw identify and quantify mitochrondrial variants from [PacBio HiFi](https://www.pacb.com/technology/hifi-sequencing/) datasets.
+Mitorsaw identifies and quantifies mitochondrial variants from [PacBio HiFi](https://www.pacb.com/technology/hifi-sequencing/) datasets.
 Key features include:
 
 * Identification of homoplasmic and heteroplasmic variants for the full length of the mitochondria


### PR DESCRIPTION
# v0.2.2
## Fixed
- Fixed an issue where the tool would panic if the max iterations on consensus was reached instead of returning the last result
- Fixed an issue where the consensus could "ping-pong" between two answers and not converge
- Fixed an issue caused by reads that are unexpectedly large (>75 kbp) by filtering them